### PR TITLE
After saving the base configuration, the colon is removed from the URLs

### DIFF
--- a/_tools/studio/application/Classes/Bases/Base.php
+++ b/_tools/studio/application/Classes/Bases/Base.php
@@ -159,7 +159,7 @@ class Bases_Base extends MVC_Base
 					$value = strtolower( $value );
 					$value = str_replace( 'http://', '', $value );
 					$value = str_replace( 'https://', '', $value );
-					$value = preg_replace( '/[^a-z0-9-.\/]/i', '', $value );
+					$value = preg_replace( '/[^a-z0-9-.\/:]/i', '', $value );
 					$value = preg_replace( '~([/]{2,})~', '/', $value );
 					//$value = preg_replace( '~([-]{2,})~', '-', $value );
 					$value = preg_replace( '~([.]{2,})~', '.', $value );


### PR DESCRIPTION
When saving the base configuration in JetStudio, the colon is removed from the URLs if they contain it. 